### PR TITLE
Refactor stamina HUD and update version numbers to 0.6.1

### DIFF
--- a/Hud/HudVigorBar.cs
+++ b/Hud/HudVigorBar.cs
@@ -11,7 +11,6 @@ namespace Vigor.Hud
     {
         // Linear bar UI elements (used when radial HUD is disabled)
         private GuiElementStatbar _staminaStatbar;
-        private GuiElementStatbar _recoveryThresholdStatbar;
         
         // Radial HUD support
         private bool _useRadial;
@@ -30,6 +29,8 @@ namespace Vigor.Hud
         private bool _hideStaminaOnFull;
         // TEMP: hide stamina bar to verify recovery overlay independently
         private bool _debugHideStaminaBar = false;
+        private float? _lastRecoveryMarkerValue;
+        private long _recoveryMarkerVisibleSinceMs;
         // Auto-hide controls
         private bool _autoHideEnabled;
         private bool _hudOpen;
@@ -284,10 +285,6 @@ namespace Vigor.Hud
                 statsBarWidth
             )
             .WithFixedHeight(10); // statbar height verified
-            
-            // Create recovery bar bounds - same alignment as main bar
-            var recoveryBarBounds = statbarBounds.FlatCopy();
-            
 
             // Create parent bounds and apply both X and Y offset at this level - the true parent container
             var barParentBounds = statsBarBounds.FlatCopy()
@@ -297,21 +294,16 @@ namespace Vigor.Hud
             
             // Set up bar colors with sufficient alpha for background visibility
             double[] staminaBarColor = { 0.85, 0.65, 0, 0.5 }; // Use alpha 0.5 to match HydrateOrDiedrate
-            double[] recoveryBarColor = { staminaBarColor[0] * 0.6, staminaBarColor[1] * 0.6, staminaBarColor[2], 0.5 };
 
             // Create composer using the parent bounds - exactly like HydrateOrDiedrate
             var composer = capi.Gui.CreateCompo("vigorhud", barParentBounds);
             
             // Begin with child elements in stats bounds
             composer.BeginChildElements(statsBarBounds);
-            
-            // Add recovery bar first (to be in the background)
-            _recoveryThresholdStatbar = new GuiElementStatbar(composer.Api, recoveryBarBounds, recoveryBarColor, isRight, false);
-
-            composer.AddInteractiveElement(_recoveryThresholdStatbar, "recoverybar");
 
             // Add main stamina bar
             _staminaStatbar = new GuiElementStatbar(composer.Api, statbarBounds, staminaBarColor, isRight, false);
+            _staminaStatbar.PreviousValueDisplayTime = 3600f; // Keep the recovery marker persistent while active
             composer.AddInteractiveElement(_staminaStatbar, "staminabar");
             
             // End child elements and compose
@@ -332,7 +324,7 @@ namespace Vigor.Hud
                 return;
             }
 
-            if (_staminaStatbar == null || _recoveryThresholdStatbar == null) return;
+            if (_staminaStatbar == null) return;
 
             // Clamp/snap values to avoid > max and guarantee full-hide behavior
             float max = Math.Max(1f, _displayedMaxStamina);
@@ -357,29 +349,40 @@ namespace Vigor.Hud
                 _staminaStatbar.SetValues(stam, 0, max);
                 _staminaStatbar.ShouldFlash = _displayedIsExhausted;
             }
-            // The line interval should also be based on the *current* max stamina
-            // Draw a line every 100 stamina points, similar to the vanilla hunger bar.
-            _staminaStatbar.SetLineInterval(1500f / max);
-             
-            // Update recovery threshold bar
-            // Respect config: optionally hide recovery threshold entirely
-            float recoveryValue;
-            if (VigorModSystem.Instance.CurrentConfig.HideRecoveryThreshold)
+
+            // Vanilla-style single-statbar overlay: use the statbar's previous-value layer
+            // so the threshold inherits the bar's yellow/orange palette instead of the
+            // hardcoded green future-value projection used by vanilla healing.
+            float? recoveryMarkerValue = null;
+            var config = VigorModSystem.Instance.CurrentConfig;
+            if (!config.HideRecoveryThreshold)
             {
-                recoveryValue = 0f;
+                if (_displayedIsExhausted && _displayedRecoveryThreshold > 0.01f)
+                {
+                    recoveryMarkerValue = Math.Clamp(_displayedRecoveryThreshold, 0f, max);
+                }
+            }
+            _staminaStatbar.SetFutureValues(null, 0f);
+
+            long nowMs = capi.InWorldEllapsedMilliseconds;
+            if (recoveryMarkerValue.HasValue)
+            {
+                if (!_lastRecoveryMarkerValue.HasValue || Math.Abs(_lastRecoveryMarkerValue.Value - recoveryMarkerValue.Value) > 0.01f)
+                {
+                    _recoveryMarkerVisibleSinceMs = nowMs;
+                    _lastRecoveryMarkerValue = recoveryMarkerValue.Value;
+                }
             }
             else
             {
-                // If exhausted, show the threshold. If not exhausted, draw no fill (0) to avoid a full-width bar
-                recoveryValue = _displayedIsExhausted ? _displayedRecoveryThreshold : 0f;
+                _lastRecoveryMarkerValue = null;
+                _recoveryMarkerVisibleSinceMs = nowMs;
             }
-            if (recoveryValue < 0f) recoveryValue = 0f;
-            if (recoveryValue > max) recoveryValue = max;
-            // Do NOT snap recovery to max; we want it visible throughout exhaustion, even if near max
-            _recoveryThresholdStatbar.SetValues(recoveryValue, 0, max);
-            _recoveryThresholdStatbar.SetLineInterval(1500f / max);
+            _staminaStatbar.SetPrevValue(recoveryMarkerValue, _recoveryMarkerVisibleSinceMs, () => capi.InWorldEllapsedMilliseconds);
 
-            // Note: Recovery bar HideWhenFull=true, setting value == max hides it internally
+            // The line interval should also be based on the *current* max stamina
+            // Draw a line every 100 stamina points, similar to the vanilla hunger bar.
+            _staminaStatbar.SetLineInterval(1500f / max);
         }
         
         /// <summary>

--- a/Hud/StaminaRadialRenderer.cs
+++ b/Hud/StaminaRadialRenderer.cs
@@ -41,29 +41,23 @@ namespace Vigor.Hud
             float inner = GameMath.Clamp(cfg.RadialInnerRadius, 0.0f, 1.0f);
             float outer = GameMath.Clamp(cfg.RadialOuterRadius, inner + 0.01f, 2.0f);
 
-            // Upload full ring background
-            // Full ring; start at 12 o'clock for consistency
             MeshData bgRing = CreateRing(inner, outer, Steps, -Math.PI / 2, 2 * Math.PI, ColorUtil.BlackArgb);
             _backgroundRingMesh = _capi.Render.UploadMesh(bgRing);
 
-            // Upload stamina meshes for 0..100%
             _staminaMeshes = new MeshRef[Steps + 1];
             for (int i = 0; i <= Steps; i++)
             {
                 float percent = i / (float)Steps;
-                // Clockwise fill from 12 o'clock: negative angle range
                 MeshData mesh = CreateRing(inner, outer, Steps, -Math.PI / 2, -2 * Math.PI * percent, ColorUtil.BlackArgb);
                 _staminaMeshes[i] = _capi.Render.UploadMesh(mesh);
             }
 
-            // Precompute thin threshold indicator arcs for each percent position
             _thresholdMeshes = new MeshRef[Steps + 1];
             float thOuter = outer;
-            float thInner = (inner + outer) * 0.5f; // mid-line thickness
-            double tickRange = 2 * Math.PI * 0.01f; // ~1% arc
+            float thInner = (inner + outer) * 0.5f;
+            double tickRange = 2 * Math.PI * 0.01f;
             for (int i = 0; i <= Steps; i++)
             {
-                // Clockwise position from 12 o'clock
                 double start = -Math.PI / 2 - 2 * Math.PI * (i / (double)Steps);
                 MeshData arc = CreateArc(thInner, thOuter, Steps, start, tickRange, ColorUtil.BlackArgb);
                 _thresholdMeshes[i] = _capi.Render.UploadMesh(arc);
@@ -81,7 +75,6 @@ namespace Vigor.Hud
             bool exhausted = snap.IsExhausted;
             float threshold = GameMath.Clamp(snap.RecoveryThreshold, 0f, max);
 
-            // Hide when visually full with tolerance, to account for prediction rounding
             if (cfg.HideStaminaOnFull && (stamina / max) >= 0.999f && !exhausted)
             {
                 return;
@@ -103,7 +96,6 @@ namespace Vigor.Hud
             shader.Uniform("tex2d", 0);
             shader.Uniform("noTexture", 1f);
 
-            // Background ring (flashes red when exhausted)
             if (exhausted)
             {
                 float flashAlpha = 0.3f + 0.2f * GameMath.Sin(_exhaustedFlashTimer * 5f);
@@ -115,16 +107,13 @@ namespace Vigor.Hud
             }
             _capi.Render.RenderMesh(_backgroundRingMesh);
 
-            // Stamina ring (yellow - match statbar coloration)
             float staminaPercentRaw = GameMath.Clamp(stamina / max, 0f, 1f);
-            // Exponential smoothing to reduce visible stutter from reconciliation
             if (_smoothedPercent < 0f)
             {
                 _smoothedPercent = staminaPercentRaw;
             }
             else
             {
-                // smoothing factor ~12 Hz response
                 float alpha = 1f - (float)Math.Exp(-dt * 12f);
                 _smoothedPercent = GameMath.Clamp(_smoothedPercent + (staminaPercentRaw - _smoothedPercent) * alpha, 0f, 1f);
             }
@@ -133,16 +122,16 @@ namespace Vigor.Hud
             shader.Uniform("rgbaIn", new Vec4f(0.85f, 0.65f, 0f, 0.7f));
             _capi.Render.RenderMesh(_staminaMeshes[idx]);
 
-            // Recovery threshold indicator (draw only when exhausted to match bar semantics)
-            if (!VigorModSystem.Instance.CurrentConfig.HideRecoveryThreshold && exhausted && threshold > 0)
+            bool showThreshold = !cfg.HideRecoveryThreshold && exhausted && threshold > 0f;
+
+            if (showThreshold)
             {
                 float thPercent = GameMath.Clamp(threshold / max, 0f, 1f);
                 int thIdx = GameMath.Clamp((int)(thPercent * Steps), 0, Steps);
-                // Draw a small band (±1 step) around the threshold for better visibility
                 int halfWidth = 1;
                 int start = GameMath.Clamp(thIdx - halfWidth, 0, Steps);
                 int end = GameMath.Clamp(thIdx + halfWidth, 0, Steps);
-                shader.Uniform("rgbaIn", new Vec4f(1f, 0.65f, 0f, 0.5f)); // orange accent
+                shader.Uniform("rgbaIn", new Vec4f(1f, 0.65f, 0f, 0.5f));
                 for (int i = start; i <= end; i++)
                 {
                     _capi.Render.RenderMesh(_thresholdMeshes[i]);
@@ -185,7 +174,6 @@ namespace Vigor.Hud
 
         private static MeshData CreateRing(float innerRadius, float outerRadius, int divisions, double startAngle, double angleRange, int color)
         {
-            // Heavily inspired by Bloodshed's MeshUtil.GetRing
             int segs = Math.Max(1, divisions * 4);
             MeshData mesh = new MeshData(segs * 2 * 2, segs * 2 * 3, false, true, true, false);
             mesh.SetMode(EnumDrawMode.Triangles);
@@ -215,7 +203,6 @@ namespace Vigor.Hud
 
         private static MeshData CreateArc(float innerRadius, float outerRadius, int divisions, double startAngle, double angleRange, int color)
         {
-            // Same as CreateRing but offset by startAngle
             int segs = Math.Max(1, divisions * 4);
             MeshData mesh = new MeshData(segs * 2 * 2, segs * 2 * 3, false, true, true, false);
             mesh.SetMode(EnumDrawMode.Triangles);

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("0.6.0.0")]
-[assembly: AssemblyFileVersion("0.6.0.0")]
+[assembly: AssemblyVersion("0.6.1.0")]
+[assembly: AssemblyFileVersion("0.6.1.0")]

--- a/modinfo.json
+++ b/modinfo.json
@@ -3,7 +3,7 @@
   "modid": "vigor",
   "name": "Vigor",
   "authors": ["chrisunfocused"],
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A streamlined stamina and exhaustion system for Vintage Story.",
   "dependencies": {
     "game": "1.22.0" 


### PR DESCRIPTION
This pull request updates the Vigor HUD stamina bar to simplify the linear (non-radial) display and improve the way the recovery threshold is shown. The main change is the removal of the separate recovery threshold bar in the linear HUD; instead, the recovery threshold is now displayed as a persistent marker overlay within the main stamina bar, matching the style of the radial HUD. The update also includes minor code cleanups and a version bump.

**HUD Linear Bar Refactor:**

* Removed the separate `GuiElementStatbar` for the recovery threshold in `HudVigorBar`, consolidating the recovery threshold display into the main `_staminaStatbar` using its previous-value marker layer. This makes the UI simpler and more consistent with the radial HUD. [[1]](diffhunk://#diff-b3acf1c3528642f10e170cd7fb401564ddbcca0b09d97447527af50216203622L14) [[2]](diffhunk://#diff-b3acf1c3528642f10e170cd7fb401564ddbcca0b09d97447527af50216203622L288-L291) [[3]](diffhunk://#diff-b3acf1c3528642f10e170cd7fb401564ddbcca0b09d97447527af50216203622L300-R306) [[4]](diffhunk://#diff-b3acf1c3528642f10e170cd7fb401564ddbcca0b09d97447527af50216203622L335-R327) [[5]](diffhunk://#diff-b3acf1c3528642f10e170cd7fb401564ddbcca0b09d97447527af50216203622L360-R385)
* Added logic to persist and update the recovery marker value and its display timing within the main stamina bar, ensuring the marker remains visible as appropriate. [[1]](diffhunk://#diff-b3acf1c3528642f10e170cd7fb401564ddbcca0b09d97447527af50216203622R32-R33) [[2]](diffhunk://#diff-b3acf1c3528642f10e170cd7fb401564ddbcca0b09d97447527af50216203622L360-R385)

**Radial HUD and Rendering Cleanups:**

* Refactored comments and variable usage in `StaminaRadialRenderer` for clarity and consistency, and made minor code cleanups without changing rendering behavior. [[1]](diffhunk://#diff-bd77d76eb66f2e8b2e0fc58dca3ecf1812a308d7262833297b93ee3557fdbde0L44-L66) [[2]](diffhunk://#diff-bd77d76eb66f2e8b2e0fc58dca3ecf1812a308d7262833297b93ee3557fdbde0L84) [[3]](diffhunk://#diff-bd77d76eb66f2e8b2e0fc58dca3ecf1812a308d7262833297b93ee3557fdbde0L106) [[4]](diffhunk://#diff-bd77d76eb66f2e8b2e0fc58dca3ecf1812a308d7262833297b93ee3557fdbde0L118-L127) [[5]](diffhunk://#diff-bd77d76eb66f2e8b2e0fc58dca3ecf1812a308d7262833297b93ee3557fdbde0L136-R134) [[6]](diffhunk://#diff-bd77d76eb66f2e8b2e0fc58dca3ecf1812a308d7262833297b93ee3557fdbde0L188) [[7]](diffhunk://#diff-bd77d76eb66f2e8b2e0fc58dca3ecf1812a308d7262833297b93ee3557fdbde0L218)

**Version Update:**

* Bumped the mod version to `0.6.1` in both `AssemblyInfo.cs` and `modinfo.json` to reflect these changes. [[1]](diffhunk://#diff-757a32ebd700217ce368eb8576ea976f8e6324c1589bd30f801e94aac8612014L33-R34) [[2]](diffhunk://#diff-8a1ec96d889839b7260c3c2e188afeb9d2db1d64a8dca6c207b562c9715cb642L6-R6)Update version numbers to 0.6.1 for AssemblyInfo and modinfo